### PR TITLE
Remove binpack references from codebase

### DIFF
--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -74,7 +74,7 @@ def main():
     parser = argparse.ArgumentParser(description="")
     parser.add_argument("--net", type=str, help="path to a .nnue net")
     parser.add_argument("--engine", type=str, help="path to stockfish")
-    parser.add_argument("--data", type=str, help="path to a .bin or .binpack dataset")
+    parser.add_argument("--data", type=str, help="path to a .bin dataset")
     parser.add_argument("--checkpoint", type=str, help="Optional checkpoint (used instead of nnue for local eval)")
     parser.add_argument("--count", type=int, default=100, help="number of datapoints to process")
     features.add_argparse_args(parser)

--- a/lib/nnue_training_data_formats.h
+++ b/lib/nnue_training_data_formats.h
@@ -440,7 +440,7 @@ namespace chess
 
 }
 
-namespace binpack
+namespace bin
 {
     constexpr std::size_t KiB = 1024;
     constexpr std::size_t MiB = (1024*KiB);

--- a/lib/nnue_training_data_stream.h
+++ b/lib/nnue_training_data_stream.h
@@ -10,7 +10,7 @@
 
 namespace training_data {
 
-    using namespace binpack;
+    using namespace bin;
 
     static bool ends_with(const std::string& lhs, const std::string& end)
     {

--- a/perf_sigmoid_fitter.py
+++ b/perf_sigmoid_fitter.py
@@ -81,7 +81,7 @@ def gather_statistics_from_batches(batches, bucket_size):
 
 def gather_statistics_from_data(filename, count, bucket_size):
     '''
-    Takes a .bin or .binpack file and produces perf% statistics
+    Takes a .bin file and produces perf% statistics
     The result is a dictionary of the form { eval : (perf%, count) }
     '''
     batch_size = 8192

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 python train.py \
- ../data/large_gensfen_multipvdiff_100_d9.binpack \
- ../data/large_gensfen_multipvdiff_100_d9.binpack \
+ ../data/large_gensfen_multipvdiff_100_d9.bin \
+ ../data/large_gensfen_multipvdiff_100_d9.bin \
  --gpus 1 \
  --threads 2 \
  --batch-size 8096 \

--- a/train.py
+++ b/train.py
@@ -23,11 +23,11 @@ def make_data_loaders(train_filename, val_filename, feature_set, num_workers, ba
 
 def main():
   parser = argparse.ArgumentParser(description="Trains the network.")
-  parser.add_argument("train", help="Training data (.bin or .binpack)")
-  parser.add_argument("val", help="Validation data (.bin or .binpack)")
+  parser.add_argument("train", help="Training data (.bin)")
+  parser.add_argument("val", help="Validation data (.bin)")
   parser = pl.Trainer.add_argparse_args(parser)
   parser.add_argument("--lambda", default=1.0, type=float, dest='lambda_', help="lambda=1.0 = train on evaluations, lambda=0.0 = train on game results, interpolates between (default=1.0).")
-  parser.add_argument("--num-workers", default=1, type=int, dest='num_workers', help="Number of worker threads to use for data loading. Currently only works well for binpack.")
+  parser.add_argument("--num-workers", default=1, type=int, dest='num_workers', help="Number of worker threads to use for data loading. Currently only works well for bin.")
   parser.add_argument("--batch-size", default=-1, type=int, dest='batch_size', help="Number of positions per batch / per iteration. Default on GPU = 8192 on CPU = 128.")
   parser.add_argument("--threads", default=-1, type=int, dest='threads', help="Number of torch threads to use. Default automatic (cores) .")
   parser.add_argument("--seed", default=42, type=int, dest='seed', help="torch seed to use.")

--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -26,7 +26,7 @@
 #endif
 #endif
 
-using namespace binpack;
+using namespace bin;
 using namespace chess;
 
 static constexpr int MAX_PIECES = PIECE_COUNT;
@@ -670,7 +670,7 @@ extern "C" {
 
 int main()
 {
-    auto stream = create_sparse_batch_stream("HalfKP", 4, "10m_d3_q_2.binpack", 8192, true, false, 0);
+    auto stream = create_sparse_batch_stream("HalfKP", 4, "10m_d3_q_2.bin", 8192, true, false, 0);
     auto t0 = std::chrono::high_resolution_clock::now();
     for (int i = 0; i < 1000; ++i)
     {


### PR DESCRIPTION
- Renamed namespace binpack to bin in nnue_training_data_formats.h
- Updated using namespace statements in training_data_loader.cpp and nnue_training_data_stream.h
- Changed documentation to reference .bin instead of .binpack format
- Updated example filenames from .binpack to .bin extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)